### PR TITLE
histogram 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "histogram"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Brian Martin <brayniac@gmail.com>"]
 
 license = "MIT"


### PR DESCRIPTION
- move HistogramConfig to builder pattern (resolves #3)
- make HistogramBucket fields private (resolves #4)
- provide Histogram::configured() for when config is constructed
- Histogram::new() takes no args
- new methods for config setup
- new methods for bucket introspection