### PR TITLE
histogram 0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "histogram"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Brian Martin <brayniac@gmail.com>"]
 
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,6 +300,10 @@ impl Histogram {
             data.set_len(buckets_total as usize);
         }
 
+        for i in 0..data.len() {
+            data[i] = 0;
+        }
+
         let counters = HistogramCounters::new();
 
         Some(Histogram {


### PR DESCRIPTION
- bugfix: don't rely on 0's in uninitialized Vec<u64>, broke on OSX VM
- bump version to 0.3.1