### PR TITLE
histogram 0.3.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "histogram"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Brian Martin <brayniac@gmail.com>"]
 
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -541,7 +541,7 @@ impl Histogram {
 
                 index += step;
 
-                if index > self.buckets_total() as isize {
+                if index >= self.buckets_total() as isize {
                     break;
                 }
                 if index < 0 {
@@ -1040,4 +1040,26 @@ mod tests {
         assert_eq!(h.percentile(95.0).unwrap(), 195);
         assert_eq!(h.percentile(100.0).unwrap(), 199);
     }
+
+   #[test]
+   fn test_percentile_bad() {
+       let mut c = HistogramConfig::new();
+       c.max_value(1_000).precision(4);
+       let mut h = Histogram::configured(c).unwrap();
+
+       let _ = h.increment(5_000);
+
+       assert!(h.percentile(0.0).is_err());
+       assert!(h.percentile(50.0).is_err());
+       assert!(h.percentile(100.0).is_err());
+
+       let _ = h.increment(1);
+
+       assert!(h.percentile(0.0).is_ok());
+
+       let _ = h.increment(500);
+       let _ = h.increment(500);
+
+       assert!(h.percentile(50.0).is_ok());
+   }
 }


### PR DESCRIPTION
- fix out-of-bounds for percentiles when overflowed values are present
- add test to prevent regression